### PR TITLE
docs(billing): agregar documentación de entitlements y planes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ IISExpress/
 
 # User secrets / locales
 appsettings.*.local.json
+appsettings.*.json
 *.user
 *.suo
 

--- a/Docs/Billing/Leer el límite de almacenamiento (storage.gb).sql
+++ b/Docs/Billing/Leer el límite de almacenamiento (storage.gb).sql
@@ -1,0 +1,11 @@
+--6D318048-0D53-4695-A196-57C9CC4B94E4
+--7A1A5713-118D-4362-A2CB-F3CE164E3CCA
+DECLARE @OrgId UNIQUEIDENTIFIER = '7A1A5713-118D-4362-A2CB-F3CE164E3CCA';
+
+SELECT TOP (1)
+       /* usa la columna correcta */ feature_code /* ó feature_code */ AS entitlement,
+       limit_value AS gb_limit,
+       (limit_value * 1024.0 * 1024.0 * 1024.0) AS bytes_limit
+FROM dbo.entitlements
+WHERE org_id = @OrgId
+  AND ( /* usa la columna correcta */ feature_code /* ó feature_code */ ) = 'storage.gb';

--- a/Docs/Billing/Reconciliar usados vs. límite (adjuntos).sql
+++ b/Docs/Billing/Reconciliar usados vs. límite (adjuntos).sql
@@ -1,0 +1,18 @@
+﻿DECLARE @OrgId UNIQUEIDENTIFIER = '7A1A5713-118D-4362-A2CB-F3CE164E3CCA';
+
+-- Límite en GB → bytes
+WITH limit_cte AS (
+  SELECT TOP (1)
+         (limit_value * 1024 * 1024 * 1024) AS limit_bytes
+  FROM dbo.entitlements
+  WHERE org_id = @OrgId
+    AND feature_code = 'storage.gb'
+),
+used_cte AS (
+  SELECT SUM(CASE WHEN deleted_at_utc IS NULL THEN byte_size ELSE 0 END) AS used_bytes
+  FROM dbo.patient_files
+  WHERE org_id = @OrgId
+)
+SELECT u.used_bytes, l.limit_bytes,
+       CASE WHEN l.limit_bytes > 0 THEN (100.0 * u.used_bytes / l.limit_bytes) ELSE NULL END AS used_pct
+FROM used_cte u CROSS JOIN limit_cte l;

--- a/Docs/Billing/entitlements_seed.sql
+++ b/Docs/Billing/entitlements_seed.sql
@@ -1,0 +1,124 @@
+
+---
+
+# `db/seeds/entitlements_seed.sql`
+
+> Script idempotente para **aplicar/actualizar** entitlements a una organización según un `@PlanCode`.  
+> Incluye dos variantes para la columna del código del entitlement en la tabla `entitlements`: `code` **o** `feature_code`. **Descomenta una u otra** según tu esquema.
+
+```sql
+/* db/seeds/entitlements_seed.sql
+   Aplica entitlements por plan a una organización específica.
+   - Idempotente (usa MERGE).
+   - Ajusta @OrgId y @PlanCode.
+   - Descomenta el MERGE que corresponda a tu esquema:
+       · Variante A: la columna se llama [code]
+       · Variante B: la columna se llama [feature_code]
+*/
+
+SET NOCOUNT ON;
+
+DECLARE @OrgId     UNIQUEIDENTIFIER = '7A1A5713-118D-4362-A2CB-F3CE164E3CCA';
+DECLARE @PlanCode  NVARCHAR(50)     = 'solo';   -- 'solo' | 'clinic' | 'pro'
+DECLARE @UtcNow    DATETIME2(7)     = SYSUTCDATETIME();
+
+-- Normalizamos a minúsculas para comparar
+SET @PlanCode = LOWER(@PlanCode);
+
+IF OBJECT_ID('tempdb..#limits') IS NOT NULL DROP TABLE #limits;
+CREATE TABLE #limits (
+  code        NVARCHAR(50) NOT NULL,
+  limit_value INT          NOT NULL
+);
+
+-- Cargar mapa por plan
+IF (@PlanCode = 'solo')
+BEGIN
+  INSERT INTO #limits(code, limit_value) VALUES
+    ('ai.opinion.monthly', 50),
+    ('tests.auto.monthly', 20),
+    ('sacks.monthly',      5),
+    ('seats',              1),
+    ('storage.gb',         10);
+END
+ELSE IF (@PlanCode = 'clinic')
+BEGIN
+  INSERT INTO #limits(code, limit_value) VALUES
+    ('ai.opinion.monthly', 200),
+    ('tests.auto.monthly', 100),
+    ('sacks.monthly',      20),
+    ('seats',              5),
+    ('storage.gb',         50);
+END
+ELSE IF (@PlanCode = 'pro')
+BEGIN
+  INSERT INTO #limits(code, limit_value) VALUES
+    ('ai.opinion.monthly', 1000),
+    ('tests.auto.monthly', 500),
+    ('sacks.monthly',      100),
+    ('seats',              20),
+    ('storage.gb',         200);
+END
+ELSE
+BEGIN
+  RAISERROR('PlanCode desconocido. Use solo | clinic | pro', 16, 1);
+  RETURN;
+END
+
+/* =======================================================================================
+   VARIANTE A — usa [code] como nombre de columna del entitlement en dbo.entitlements
+   ---------------------------------------------------------------------------------------
+   Descomenta este bloque si tu tabla dbo.entitlements tiene columnas: 
+     org_id UNIQUEIDENTIFIER, code NVARCHAR(50), limit_value INT, updated_at_utc DATETIME2(7), ...
+---------------------------------------------------------------------------------------*/
+/*
+MERGE dbo.entitlements AS tgt
+USING (
+  SELECT @OrgId AS org_id, code, limit_value
+  FROM #limits
+) AS src
+ON  tgt.org_id = src.org_id
+AND tgt.code   = src.code
+WHEN MATCHED THEN
+  UPDATE SET 
+    tgt.limit_value    = src.limit_value,
+    tgt.updated_at_utc = @UtcNow
+WHEN NOT MATCHED BY TARGET THEN
+  INSERT (org_id, code, limit_value, updated_at_utc)
+  VALUES (src.org_id, src.code, src.limit_value, @UtcNow)
+WHEN NOT MATCHED BY SOURCE AND tgt.org_id = @OrgId THEN
+  DELETE
+;
+*/
+
+/* =======================================================================================
+   VARIANTE B — usa [feature_code] como nombre de columna del entitlement en dbo.entitlements
+   -------------------------------------------------------------------------------------------
+   Descomenta este bloque si tu tabla dbo.entitlements tiene columnas:
+     org_id UNIQUEIDENTIFIER, feature_code NVARCHAR(50), limit_value INT, updated_at_utc DATETIME2(7), ...
+-------------------------------------------------------------------------------------------*/
+/*
+MERGE dbo.entitlements AS tgt
+USING (
+  SELECT @OrgId AS org_id, code AS feature_code, limit_value
+  FROM #limits
+) AS src
+ON  tgt.org_id      = src.org_id
+AND tgt.feature_code = src.feature_code
+WHEN MATCHED THEN
+  UPDATE SET 
+    tgt.limit_value    = src.limit_value,
+    tgt.updated_at_utc = @UtcNow
+WHEN NOT MATCHED BY TARGET THEN
+  INSERT (org_id, feature_code, limit_value, updated_at_utc)
+  VALUES (src.org_id, src.feature_code, src.limit_value, @UtcNow)
+WHEN NOT MATCHED BY SOURCE AND tgt.org_id = @OrgId THEN
+  DELETE
+;
+*/
+
+-- Verificación
+SELECT *
+FROM dbo.entitlements
+WHERE org_id = @OrgId
+ORDER BY /* usa la columna correcta */ code /* ó feature_code */;

--- a/Docs/billing-entitlements.md
+++ b/Docs/billing-entitlements.md
@@ -1,0 +1,52 @@
+# Billing · Entitlements y Planes
+
+Este documento resume los **entitlements** activos del producto y cómo se aplican por **plan** (solo / clínica / pro). Sirve como referencia funcional y técnica para backend y frontend.
+
+---
+
+## Entitlements activos
+
+- `ai.opinion.monthly` — Límite mensual de opiniones generadas por IA.
+- `tests.auto.monthly` — Límite mensual de tests automáticos.
+- `sacks.monthly` — Límite mensual de SACKs.
+- `seats` — Cantidad de usuarios/miembros.
+- `storage.gb` — Almacenamiento (GB) para **adjuntos** de pacientes (no mensual).
+
+> **Nota:** Los entitlements se guardan por organización en la tabla `entitlements`. El servicio los consulta vía `GetEntitlementLimitAsync(orgId, code)`.
+
+---
+
+## Valores por plan (simulados actuales)
+
+| Plan    | ai.opinion.monthly | tests.auto.monthly | sacks.monthly | seats | storage.gb |
+|---------|---------------------|--------------------|---------------|-------|------------|
+| solo    | 50                  | 20                 | 5             | 1     | 10         |
+| clinic  | 200                 | 100                | 20            | 5     | 50         |
+| pro     | 1000                | 500                | 100           | 20    | 200        |
+
+> Estos valores viven en el **diccionario** que arma el `BillingController` (checkout simulado / webhook) y se aplican a través del `BillingOrchestrator` a la tabla `entitlements`.
+
+---
+
+## Pipeline de aplicación
+
+1. **Checkout / Webhook** determinan `plan_code` (solo/clinic/pro).
+2. Se arma el mapa `{ entitlement_code -> valor }` según el plan.
+3. `BillingOrchestrator.ApplySubscriptionAndEntitlementsAsync(...)`:
+   - Actualiza `subscriptions` (plan/status/ventana).
+   - **Upsert** en `entitlements` con los límites vigentes.
+
+> La idempotencia del webhook se garantiza en `webhook_idempotency`. Firma HMAC verificada en `BillingController`.
+
+---
+
+## Consultas rápidas (SQL)
+
+### Ver entitlements vigentes de una organización
+```sql
+DECLARE @OrgId UNIQUEIDENTIFIER = '00000000-0000-0000-0000-000000000000';
+
+SELECT *
+FROM dbo.entitlements
+WHERE org_id = @OrgId
+ORDER BY /* usa la columna correcta */ code /* ó feature_code */;

--- a/EPApi.csproj
+++ b/EPApi.csproj
@@ -13,4 +13,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Docs\Billing\" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
docs(billing): agregar documentación de entitlements y planes
chore(db): seed idempotente de entitlements por plan (solo/clinic/pro)

- Entitlements activos: ai.opinion.monthly, tests.auto.monthly, sacks.monthly, seats, storage.gb
- Tabla comparativa por plan (valores simulados)
- SQL de verificación y reconciliación de storage
- Seed MERGE con dos variantes (code | feature_code) según esquema existente
